### PR TITLE
Refactor send message

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "./src/api/server",
   "scripts": {
     "start": "node .",
-    "dev": "nodemon ."
+    "dev": "nodemon .",
+    "lint": "eslint --no-inline-config --ext .js,.jsx --no-error-on-unmatched-pattern -c .eslintrc.json .",
+    "lint:styles": "stylelint **/*.css --config .stylelintrc.json --ignore-disables --allow-empty-input"
   },
   "repository": {
     "type": "git",

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -10,6 +10,7 @@ const messageBox = document
   .querySelector('.webchat__message__box');
 
 const saveSessionStorage = (key, value) => window.sessionStorage.setItem(key, value);
+
 const getSessionStorage = (key) => window.sessionStorage.getItem(key);
 
 const createElementsNickNameInTheBox = (nicknames) => {
@@ -45,12 +46,16 @@ const createElementsMessageInTheBox = (message) => {
 
 userButton.addEventListener('click', (_e) => {
   const nickname = document.querySelector('.webchat_nickname__input');
+
+  if (!nickname.value) return;
+
   socket.emit('nickname', nickname.value);
   saveSessionStorage('user', nickname.value);
   nickname.value = '';
 });
 
 socket.on('nickname', (nickname) => {
+  if (!nickname) return;
   saveSessionStorage('user', nickname);
 });
 

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -61,10 +61,8 @@ socket.on('listUsers', (nicknames) => {
 
 messageButton.addEventListener('click', (_e) => {
   const message = document.querySelector('.webchat__message__input');
-  // const onlineUser = document.querySelectorAll('.online-user');
-  // const nickname = onlineUser[onlineUser.length - 1].textContent;
   const nickname = getSessionStorage('user');
-  socket.emit('message', { chatMessage: message.value, nickname, socketId: socket.id });
+  socket.emit('message', { chatMessage: message.value, nickname });
 
   message.value = '';
 });

--- a/src/sockets/chat.js
+++ b/src/sockets/chat.js
@@ -14,8 +14,8 @@ io.on('connection', (socket) => {
     io.emit('listUsers', Object.values(users));
   });
 
-  socket.on('message', async ({ nickname, chatMessage, socketId = '' }) => {
-    await sendMessage({ socketId, nickname, chatMessage, io, users });
+  socket.on('message', async ({ nickname, chatMessage }) => {
+    await sendMessage({ nickname, chatMessage, io, users });
   });
 
   socket.on('disconnect', () => {

--- a/src/utils/sendMessage.js
+++ b/src/utils/sendMessage.js
@@ -1,17 +1,9 @@
 const moment = require('moment');
 const postsModel = require('../models');
 
-module.exports = async ({ socketId, nickname, chatMessage, io, users }) => {
-  if (!socketId) {
+module.exports = async ({ nickname, chatMessage, io }) => {
     const timestamp = moment().format('DD-MM-YYYY HH:mm:ss A');
     const message = `${timestamp} - ${nickname}: ${chatMessage}`;
     await postsModel.createMessages({ chatMessage, nickname });
     io.emit('message', message);
-    return;
-  }
-  const nickName = users[socketId];
-  const timestamp = moment().format('DD-MM-YYYY HH:mm:ss A');
-  const message = `${timestamp} - ${nickName}: ${chatMessage}`;
-  await postsModel.createMessages({ chatMessage, nickname });
-  io.emit('message', message);
 };


### PR DESCRIPTION
Foi retatorada a função da pasta utils sendMessage. Antes era necessário enviar o socket.id do usuário logado, agora apenas é necessário enviar o próprio nickname. E foi resolvido o problema do usuário poder enviar um nickname vazio.